### PR TITLE
Replace comma with period

### DIFF
--- a/src/epub/text/albergo-empedocle.xhtml
+++ b/src/epub/text/albergo-empedocle.xhtml
@@ -19,7 +19,7 @@
 				</footer>
 			</blockquote>
 			<p>I did not go. I could just have managed it, but Sicily was then a very sacred name to me, and the thought of running through it in no time, even with Harold, deterred me. I went afterwards, and as I am well acquainted with all who went then, and have had circumstantial information of all that happened, I think that my account of the affair will be as intelligible as anyone’s.</p>
-			<p>I am conceited enough to think that if I had gone, the man I love most in the world would not now be in an asylum,</p>
+			<p>I am conceited enough to think that if I had gone, the man I love most in the world would not now be in an asylum.</p>
 			<section id="albergo-empedocle-1" epub:type="chapter">
 				<h3 epub:type="ordinal z3998:roman">I</h3>
 				<p>The Peaslake party was most harmonious in its composition. Four out of the five were Peaslakes, which partly accounted for the success, but the fifth, Harold, seemed to have been created to go with them. They had started from England soon after his engagement to Mildred Peaslake, and had been flying over Europe for two months. At first they were a little ashamed of their rapidity, but the delight of continual customhouse examinations soon seized them, and they had hardly learnt what “Come in,” and “Hot water, please,” were in one language, before they crossed the frontier and had to learn them in another.</p>


### PR DESCRIPTION
The end of this sentence should be a period, both grammatically and according to the scan of this same story on [page 663 of this collection on the Internet Archive](https://archive.org/details/sim_temple-bar_1903-12_128_517/page/663/mode/1up).